### PR TITLE
Clay adaptations 1

### DIFF
--- a/src/scicloj/kindly_render/note/to_hiccup.cljc
+++ b/src/scicloj/kindly_render/note/to_hiccup.cljc
@@ -17,13 +17,15 @@
              (str/replace "/" "-")))))
 
 (defn kindly-style [hiccup {:as advice :keys [kind kindly/options]}]
-  {:pre [kind]}
-  (let [m (-> (select-keys options [:class :style])
-              (update :class extend-class kind))
-        [tag attrs & more] hiccup]
-    (if (map? attrs)
-      (update hiccup 1 kindly/deep-merge m)
-      (into [tag m] more))))
+  (if kind
+    (let [m (-> (select-keys options [:class :style])
+                (update :class extend-class kind))
+          [tag attrs & more] hiccup]
+      (if (map? attrs)
+        (update hiccup 1 kindly/deep-merge m)
+        (into [tag m] more)))
+    ;; else - no kind
+    hiccup))
 
 (defn render [note]
   (let [advice (walk/derefing-advise note)

--- a/src/scicloj/kindly_render/shared/walk.cljc
+++ b/src/scicloj/kindly_render/shared/walk.cljc
@@ -8,15 +8,19 @@
 (defn derefing-advise
   "Kind priority is inside out: kinds on the value supersedes kinds on the ref."
   [note]
-  (let [note (ka/advise note)
-        {:keys [value]} note]
-    (if (instance? clojure.lang.IDeref value)
-      (let [v @value
-            meta-kind (kc/meta-kind v)]
-        (-> (assoc note :value v)
-            (cond-> meta-kind (assoc note :meta-kind meta-kind))
-            (derefing-advise)))
-      note)))
+  (if (or (:form note)
+          (:value note))
+    (let [note (ka/advise note)
+          {:keys [value]} note]
+      (if (instance? clojure.lang.IDeref value)
+        (let [v @value
+              meta-kind (kc/meta-kind v)]
+          (-> (assoc note :value v)
+              (cond-> meta-kind (assoc note :meta-kind meta-kind))
+              (derefing-advise)))
+        note))
+    ;; else - neither form nor value - no need for advice
+    note))
 
 (defn render-data-recursively
   "Data kinds like vectors, maps, sets, and seqs are recursively rendered."


### PR DESCRIPTION
Adapting for the Clay use case: allowing for a broader set of cases, where some context maps do not contain `:kind` (e.g. when `:value` is a number) or do not contain any of `:form` and `:value` (e.g. comments).