### PR TITLE
handles comments as markdown

### DIFF
--- a/src/scicloj/kindly_render/shared/from_markdown.cljc
+++ b/src/scicloj/kindly_render/shared/from_markdown.cljc
@@ -9,5 +9,12 @@
 ;; because we don't want flexmark or nextjournal dependencies in this project
 ;; yes, conditionally require them.
 
+(def mdctx
+  "NextJournal Markdown produces fragments (called :plain) which are rendered as :<>
+  These are better represented as a sequence, which hiccup will treat as a fragment."
+  (assoc mdt/default-hiccup-renderers
+    :plain (fn [ctx {:keys [text content]}]
+             (or text (map #(mdt/->hiccup ctx %) content)))))
+
 (defn to-hiccup [value]
-  (mdt/->hiccup (md/parse (util/kind-str value))))
+  (mdt/->hiccup mdctx (md/parse (util/kind-str value))))

--- a/src/scicloj/kindly_render/shared/util.cljc
+++ b/src/scicloj/kindly_render/shared/util.cljc
@@ -6,6 +6,5 @@
   #?(:clj  (json/write-str value)
      :cljs (js/JSON.stringify (clj->js value))))
 
-;; TODO: shouldn't need this (something upstream should have unwrapped it already)
 (defn kind-str [value]
   (str/join \newline (if (vector? value) value [value])))

--- a/src/scicloj/kindly_render/shared/walk.cljc
+++ b/src/scicloj/kindly_render/shared/walk.cljc
@@ -8,19 +8,15 @@
 (defn derefing-advise
   "Kind priority is inside out: kinds on the value supersedes kinds on the ref."
   [note]
-  (if (or (:form note)
-          (:value note))
-    (let [note (ka/advise note)
-          {:keys [value]} note]
-      (if (instance? clojure.lang.IDeref value)
-        (let [v @value
-              meta-kind (kc/meta-kind v)]
-          (-> (assoc note :value v)
-              (cond-> meta-kind (assoc note :meta-kind meta-kind))
-              (derefing-advise)))
-        note))
-    ;; else - neither form nor value - no need for advice
-    note))
+  (let [note (ka/advise note)
+        {:keys [value]} note]
+    (if (instance? clojure.lang.IDeref value)
+      (let [v @value
+            meta-kind (kc/meta-kind v)]
+        (-> (assoc note :value v)
+            (cond-> meta-kind (assoc note :meta-kind meta-kind))
+            (derefing-advise)))
+      note)))
 
 (defn render-data-recursively
   "Data kinds like vectors, maps, sets, and seqs are recursively rendered."


### PR DESCRIPTION
![Screen Shot 2024-11-22 at 1 08 42 PM](https://github.com/user-attachments/assets/be9113d1-219d-46fc-b8f1-4f49c7b1c5c7)

Previously, comments were just displayed as their code