### PR TITLE
refactors to be note oriented instead of mutable

### DIFF
--- a/examples/basic/page.clj
+++ b/examples/basic/page.clj
@@ -33,7 +33,8 @@
                 {:dataset-name "my dataset"}))
 
 (def notebook
-  {:notes [
+  {:kindly/options {:deps #{:kindly :clay}}
+   :notes [
            ;; kind-portal is not loaded, so this should render a short
            ;; message explaining its absence
            {:value portal}

--- a/src/scicloj/kindly_render/entry/hiccups.cljc
+++ b/src/scicloj/kindly_render/entry/hiccups.cljc
@@ -1,36 +1,50 @@
 (ns scicloj.kindly-render.entry.hiccups
-  (:require [scicloj.kindly-render.note.to-hiccup :as to-hiccup]
+  (:require [scicloj.kindly-render.entry.comments :as comments]
+            [scicloj.kindly-render.note.to-hiccup :as to-hiccup]
             [scicloj.kindly-render.note.to-hiccup-js :as to-hiccup-js]
-            [scicloj.kindly-render.entry.comments :as comments]
+            [scicloj.kindly-render.notes.resources :as resources]
             [scicloj.kindly-render.shared.from-markdown :as from-markdown]
             [scicloj.kindly-render.shared.walk :as walk]))
 
-(defn code-and-value
-  "Transforms a note into hiccup elements"
-  [{:as note :keys [code comment?]}]
+(defn value-hiccup
+  "Adds `:hiccup` to note if a value was rendered"
+  [note]
+  (if (walk/show? note)
+    (if (walk/js? note)
+      (to-hiccup-js/render note)
+      (to-hiccup/render note))
+    note))
+
+(defn extra-hiccups
+  "Adds hiccup for code, output, and exceptions"
+  [{:as note :keys [code out err exception kindly/options]}]
+  (let [{:keys [hide-code]} options
+        show-code (and code (not hide-code))]
+    (cond-> note
+            show-code (assoc :code-hiccup (to-hiccup/code-block code))
+            out (assoc :out-hiccup (to-hiccup/message out "Stdout"))
+            err (assoc :err-hiccup (to-hiccup/message err "Stderr"))
+            exception (assoc :ex-hiccup (to-hiccup/message (ex-message exception) "Exception")))))
+
+(defn comment-hiccup
+  "Converts inline comments to (markdown) hiccup"
+  [{:as note :keys [code]}]
+  (->> (comments/inline-markdown code)
+       (from-markdown/to-hiccup)
+       (assoc note :comment-hiccup)))
+
+(defn note-hiccups
+  "Attaches code, comment, output, exception, and value hiccup to note when applicable"
+  [{:as note :keys [comment?]}]
   (if comment?
-    [(-> (comments/inline-markdown code)
-         (from-markdown/to-hiccup))]
-    (let [note (walk/advise-deps note)
-          {:keys [out err exception kindly/options]} note
-          {:keys [hide-code hide-value]} options
-          show-code (and code (not hide-code))
-          show-value (and (contains? note :value) (not hide-value))]
-      (cond-> []
-              show-code (conj (to-hiccup/code-block code))
-              out (conj (to-hiccup/message out "Stdout"))
-              err (conj (to-hiccup/message err "Stderr"))
-              show-value (conj (if walk/*js*
-                                 (to-hiccup-js/render note)
-                                 (to-hiccup/render note)))
-              exception (conj (to-hiccup/message (ex-message exception) "Exception"))))))
+    (comment-hiccup note)
+    (-> (walk/advise-with-deps note)
+        (value-hiccup)
+        (extra-hiccups))))
 
 (defn with-hiccups
-  "Adds `:hiccups` and `:deps` to a notebook.
-  `:hiccups` represent the note code and visualization.
-  `:deps` indicate that resources are required to produce the visualizations."
-  [{:as notebook :keys [js notes] :or {js true}}]
-  (binding [walk/*js* js
-            walk/*deps* (atom #{})]
-    (assoc notebook :hiccups (doall (mapcat code-and-value notes))
-                    :deps (into @walk/*deps* (walk/optional-deps notebook)))))
+  "Updates the notes of a notebook with hiccup for display, and adds resource hiccups"
+  [notebook]
+  (-> (update notebook :notes walk/index-notes)
+      (update :notes #(map note-hiccups %))
+      (resources/with-resource-hiccups)))

--- a/src/scicloj/kindly_render/entry/markdowns.cljc
+++ b/src/scicloj/kindly_render/entry/markdowns.cljc
@@ -1,35 +1,45 @@
 (ns scicloj.kindly-render.entry.markdowns
   (:require [scicloj.kindly-render.note.to-markdown :as to-markdown]
             [scicloj.kindly-render.entry.comments :as comments]
-            [scicloj.kindly-render.shared.walk :as walk]))
+            [scicloj.kindly-render.shared.walk :as walk]
+            [scicloj.kindly-render.notes.resources :as resources]))
 
 ;; Markdown is sensitive to whitespace (especially newlines).
 ;; fragments like blocks must be separated by a blank line.
 ;; These markdown producing functions return strings with no trailing newline,
 ;; which are combined with double newline.
 
-(defn code-and-value
-  "Transforms a note into markdown strings"
-  [{:as note :keys [code comment?]}]
-  (if comment?
-    [(comments/inline-markdown code)]
-    (let [note (walk/advise-deps note)
-          {:keys [out err exception kindly/options]} note
-          {:keys [hide-code hide-value]} options
-          show-code (and code (not hide-code))
-          show-value (and (contains? note :value) (not hide-value))]
-      (cond-> []
-              show-code (conj (to-markdown/code-block code))
-              out (conj (to-markdown/message out "stdout"))
-              err (conj (to-markdown/message err "stderr"))
-              show-value (conj (to-markdown/render note))
-              exception (conj (to-markdown/message (ex-message exception) "exception"))))))
+(defn value-markdown [note]
+  (if (walk/show? note)
+    (to-markdown/render note)
+    note))
 
-(defn with-markdowns [{:as notebook :keys [js notes] :or {js true}}]
-  "Adds `:markdowns` and `:deps` to a notebook.
-  `:markdowns` represent the note code and visualization.
-  `:deps` indicate that resources are required to produce the visualizations."
-  (binding [walk/*js* js
-            walk/*deps* (atom #{})]
-    (assoc notebook :markdowns (doall (mapcat code-and-value notes))
-                    :deps (into @walk/*deps* (walk/optional-deps notebook)))))
+(defn extra-markdown [{:as note :keys [code out err exception kindly/options]}]
+  (let [{:keys [hide-code]} options
+        show-code (and code (not hide-code))]
+    (cond-> note
+            show-code (assoc :code-md (to-markdown/code-block code (walk/js? note)))
+            out (assoc :out-md (to-markdown/message out "stdout"))
+            err (assoc :err-md (to-markdown/message err "stderr"))
+            exception (assoc :ex-md (to-markdown/message (ex-message exception) "exception")))))
+
+(defn comment-hiccup
+  "Converts inline comments to (markdown) hiccup"
+  [{:as note :keys [code]}]
+  (->> (comments/inline-markdown code)
+       (assoc note :comment-md)))
+
+(defn note-markdowns
+  "Attaches code, comment, output, exception, and value hiccup to note when applicable"
+  [{:as note :keys [comment?]}]
+  (if comment?
+    (comment-hiccup note)
+    (-> (walk/advise-with-deps note)
+        (value-markdown)
+        (extra-markdown))))
+
+(defn with-markdowns [notebook]
+  "Updates the notes of a notebook with markdown for display, and adds resource hiccups"
+  (-> (update notebook :notes walk/index-notes)
+      (update :notes #(map note-markdowns %))
+      (resources/with-resource-hiccups)))

--- a/src/scicloj/kindly_render/note/to_hiccup.cljc
+++ b/src/scicloj/kindly_render/note/to_hiccup.cljc
@@ -1,91 +1,68 @@
 (ns scicloj.kindly-render.note.to-hiccup
   (:require [clojure.pprint :as pprint]
             [clojure.string :as str]
-            [scicloj.kindly.v4.api :as kindly]
             [scicloj.kindly-render.shared.walk :as walk]
             [scicloj.kindly-render.shared.util :as util]
             [scicloj.kindly-render.shared.from-markdown :as from-markdown]))
 
 (defmulti render-advice :kind)
 
-(defn kind-class [kind]
-  (when (not= kind :kind/hiccup)
-    (-> (str (symbol kind))
-        (str/replace "/" "-"))))
-
-(defn join-classes [classes]
-  (some->> (remove nil? classes)
-           (seq)
-           (str/join " ")))
-
-(defn kindly-style [hiccup {:as advice :keys [kind kindly/options]}]
-  (if (and kind (seq hiccup))
-    (let [[tag attrs & more] hiccup
-          class (join-classes [(kind-class kind)
-                               (:class options)
-                               (when (map? attrs)
-                                 (:class attrs))])
-          m (cond-> (select-keys options [:style])
-                    (not (str/blank? class)) (assoc :class class))]
-      (if (map? attrs)
-        (update hiccup 1 kindly/deep-merge m)
-        (into [tag m] more)))
-    ;; else - no kind
-    hiccup))
-
 (defn render [note]
-  (let [advice (walk/advise-deps note)
-        hiccup (render-advice advice)]
-    (kindly-style hiccup advice)))
+  (walk/advise-render-style note render-advice))
 
-(defmethod render-advice :default [{:keys [value kind]}]
-  (if kind
-    [:div
-     [:div "Unimplemented: " [:code (pr-str kind)]]
-     [:code (pr-str value)]]
-    (str value)))
+(defmethod render-advice :default [{:as note :keys [value kind]}]
+  (->> (if kind
+         [:div
+          [:div "Unimplemented: " [:code (pr-str kind)]]
+          [:code (pr-str value)]]
+         (str value))
+       (assoc note :hiccup)))
 
-(defn block [class xs]
+(defn block [class x]
   ;; TODO: can the class go on pre instead? for more visibility in the dom
-  [:pre (into [:code {:class class} xs])])
+  [:pre [:code {:class class} x]])
 
-(defn code-block [xs]
-  (block "sourceCode language-clojure source-clojure bg-light" xs))
+(defn code-block [x]
+  (block "sourceCode language-clojure source-clojure bg-light" x))
 
 (defn blockquote [xs]
   (into [:blockquote] xs))
 
-(defn result-block [xs]
-  (blockquote [(block "sourceCode language-clojure printed-clojure" xs)]))
+(defn result-block [x]
+  (blockquote [(block "sourceCode language-clojure printed-clojure" x)]))
 
 (defn pprint-block [value]
-  (result-block [(binding [*print-meta* true]
-                   (with-out-str (pprint/pprint value)))]))
+  (result-block (binding [*print-meta* true]
+                  (with-out-str (pprint/pprint value)))))
 
 (defn message [s channel]
   (blockquote [[:strong channel] (block nil s)]))
 
-(defmethod render-advice :kind/code [{:keys [code]}]
-  [:pre [:code code]])
+(defmethod render-advice :kind/code [{:as note :keys [code]}]
+  (->> (block "sourceCode" code)
+       (assoc note :hiccup)))
 
-(defmethod render-advice :kind/hidden [note])
+(defmethod render-advice :kind/hidden [note]
+  note)
 
-;; Don't show vars
-(defmethod render-advice :kind/var [note])
+(defmethod render-advice :kind/md [{:as note :keys [value]}]
+  (->> (from-markdown/to-hiccup value)
+       (assoc note :hiccup)))
 
-(defmethod render-advice :kind/md [{:keys [value]}]
-  (from-markdown/to-hiccup value))
+(defmethod render-advice :kind/html [{:as note :keys [value]}]
+  ;; TODO: is hiccup/raw well supported or do we need to do something?
+  (->> [:hiccup/raw (util/kind-str value)]
+       (assoc note :html)))
 
-(defmethod render-advice :kind/html [{:keys [value]}]
-  (util/kind-str value))
+(defmethod render-advice :kind/pprint [{:as note :keys [value]}]
+  (->> (pprint-block value)
+       (assoc note :hiccup)))
 
-(defmethod render-advice :kind/pprint [{:keys [value]}]
-  (pprint-block value))
-
-(defmethod render-advice :kind/image [{:keys [value]}]
-  (if (string? value)
-    [:img {:src value}]
-    [:div "Image kind not implemented"]))
+(defmethod render-advice :kind/image [{:as note :keys [value]}]
+  (->> (if (string? value)
+         [:img {:src value}]
+         [:div "Image kind not implemented"])
+       (assoc note :hiccup)))
 
 ;; TODO: this is problematic because it creates files
 #_(defmethod render-advice :kind/image [{:keys [value]}]
@@ -110,59 +87,63 @@
 
 ;; Data types that can be recursive
 
-(defmethod render-advice :kind/vector [{:keys [value]}]
-  (walk/render-data-recursively {:class "kind-vector"} value render))
+(defmethod render-advice :kind/vector [{:as note :keys [value]}]
+  (walk/render-data-recursively note {:class "kind-vector"} value render))
 
-(defmethod render-advice :kind/map [{:keys [value]}]
-  (walk/render-data-recursively {:class "kind-map"} (apply concat value) render))
+(defmethod render-advice :kind/map [{:as note :keys [value]}]
+  ;; kindly.css puts kind-map in a grid
+  (walk/render-data-recursively note {:class "kind-map"} (apply concat value) render))
 
-(defmethod render-advice :kind/set [{:keys [value]}]
-  (walk/render-data-recursively {:class "kind-set"} value render))
+(defmethod render-advice :kind/set [{:as note :keys [value]}]
+  (walk/render-data-recursively note {:class "kind-set"} value render))
 
-(defmethod render-advice :kind/seq [{:keys [value]}]
-  (walk/render-data-recursively {:class "kind-seq"} value render))
+(defmethod render-advice :kind/seq [{:as note :keys [value]}]
+  (walk/render-data-recursively note {:class "kind-seq"} value render))
 
 ;; Special data type hiccup that needs careful expansion
 
-(defmethod render-advice :kind/hiccup [{:keys [value]}]
-  (walk/render-hiccup-recursively value render))
+(defmethod render-advice :kind/hiccup [note]
+  (walk/render-hiccup-recursively note render))
 
-(defmethod render-advice :kind/table [{:keys [value]}]
-  (walk/render-table-recursively value render))
+(defmethod render-advice :kind/table [note]
+  (walk/render-table-recursively note render))
 
-(defmethod render-advice :kind/video [{:keys [youtube-id
+(defmethod render-advice :kind/video [{:as   note
+                                       :keys [youtube-id
                                               iframe-width
                                               iframe-height
                                               allowfullscreen
                                               embed-options]
                                        :or   {allowfullscreen true}}]
-  [:iframe
-   (merge
-     (when iframe-height
-       {:height iframe-height})
-     (when iframe-width
-       {:width iframe-width})
-     {:src             (str "https://www.youtube.com/embed/"
-                            youtube-id
-                            (some->> embed-options
-                                     (map (fn [[k v]]
-                                            (format "%s=%s" (name k) v)))
-                                     (str/join "&")
-                                     (str "?")))
-      :allowfullscreen allowfullscreen})])
+  (->> [:iframe
+        (merge
+          (when iframe-height
+            {:height iframe-height})
+          (when iframe-width
+            {:width iframe-width})
+          {:src             (str "https://www.youtube.com/embed/"
+                                 youtube-id
+                                 (some->> embed-options
+                                          (map (fn [[k v]]
+                                                 (format "%s=%s" (name k) v)))
+                                          (str/join "&")
+                                          (str "?")))
+           :allowfullscreen allowfullscreen})]
+       (assoc note :hiccup)))
 
 #?(:clj
-   (defmethod render-advice :kind/dataset [{:keys [value kindly/options]}]
+   (defmethod render-advice :kind/dataset [{:as note :keys [value kindly/options]}]
      (let [{:keys [dataset/print-range]} options]
        (-> value
-           (cond-> print-range
-                   ((resolve 'tech.v3.dataset.print/print-range) print-range))
+           (cond-> print-range ((resolve 'tech.v3.dataset.print/print-range) print-range))
            (println)
            (with-out-str)
-           (from-markdown/to-hiccup)))))
+           (from-markdown/to-hiccup)
+           (->> (assoc note :hiccup))))))
 
-(defmethod render-advice :kind/tex [{:keys [value]}]
+(defmethod render-advice :kind/tex [{:as note :keys [value]}]
   (->> (if (vector? value) value [value])
        (map (partial format "$$%s$$"))
        (str/join \newline)
-       (from-markdown/to-hiccup)))
+       (from-markdown/to-hiccup)
+       (assoc note :hiccup)))

--- a/src/scicloj/kindly_render/note/to_scittle_reagent.cljc
+++ b/src/scicloj/kindly_render/note/to_scittle_reagent.cljc
@@ -1,12 +1,14 @@
 (ns scicloj.kindly-render.note.to-scittle-reagent
   (:require [scicloj.kindly-render.note.to-hiccup-js :as to-hiccup-js]
+            [scicloj.kindly-render.note.to-hiccup :as to-hiccup]
             [scicloj.kindly-render.shared.walk :as walk]))
 
 (defmulti render-advice :kind)
 
 (defn render [note]
-  (-> (walk/advise-deps note)
-      (render-advice)))
+  (-> (walk/advise-with-deps note)
+      (render-advice)
+      (to-hiccup/kindly-style)))
 
 ;; fallback to hiccup-js
 (defmethod render-advice :default [note]
@@ -14,19 +16,19 @@
 
 ;; Data types that can be recursive
 
-(defmethod render-advice :kind/vector [{:keys [value]}]
-  (walk/render-data-recursively {:class "kind-vector"} value render-advice))
+(defmethod render-advice :kind/vector [{:as note :keys [value]}]
+  (walk/render-data-recursively note {:class "kind-vector"} value render-advice))
 
-(defmethod render-advice :kind/map [{:keys [value]}]
-  (walk/render-data-recursively {:class "kind-map"} (apply concat value) render-advice))
+(defmethod render-advice :kind/map [{:as note :keys [value]}]
+  (walk/render-data-recursively note {:class "kind-map"} (apply concat value) render-advice))
 
-(defmethod render-advice :kind/set [{:keys [value]}]
-  (walk/render-data-recursively {:class "kind-set"} value render-advice))
+(defmethod render-advice :kind/set [{:as note :keys [value]}]
+  (walk/render-data-recursively note {:class "kind-set"} value render-advice))
 
-(defmethod render-advice :kind/seq [{:keys [value]}]
-  (walk/render-data-recursively {:class "kind-seq"} value render-advice))
+(defmethod render-advice :kind/seq [{:as note :keys [value]}]
+  (walk/render-data-recursively note {:class "kind-seq"} value render-advice))
 
 ;; Special data type hiccup that needs careful expansion
 
-(defmethod render-advice :kind/hiccup [{:keys [value]}]
-  (walk/render-hiccup-recursively value render-advice))
+(defmethod render-advice :kind/hiccup [note]
+  (walk/render-hiccup-recursively note render-advice))

--- a/src/scicloj/kindly_render/notes/resources.cljc
+++ b/src/scicloj/kindly_render/notes/resources.cljc
@@ -80,14 +80,13 @@
   "Returns a map of resources organized placement (head or body)"
   [resources]
   (group-by (fn get-placement [resource]
-              (or (:placement resource)
-                  :head))
+              (or (:placement resource) :head))
             resources))
 
 (defn resource-hiccups
   [resources]
   (-> (resources-by-placement resources)
-      (update-vals #(doall (map resource-hiccup %)))))
+      (update-vals #(map resource-hiccup %))))
 
 (defn with-resource-hiccups
   "Adds hiccups organized by placement (:head or :body) for resource dependencies.

--- a/src/scicloj/kindly_render/notes/to_hiccup_page.cljc
+++ b/src/scicloj/kindly_render/notes/to_hiccup_page.cljc
@@ -1,16 +1,47 @@
 (ns scicloj.kindly-render.notes.to-hiccup-page
-  (:require [scicloj.kindly-render.entry.hiccups :as hiccups]
-            [scicloj.kindly-render.notes.resources :as resources]))
+  (:require [scicloj.kindly-render.entry.hiccups :as hiccups]))
 
-(defn page [{:as notebook :keys [resource-hiccups hiccups]}]
+(def hiccup-keys
+  [:comment-hiccup
+   :code-hiccup
+   :out-hiccup
+   :err-hiccup
+   :hiccup
+   :ex-hiccup])
+
+(defn check-hiccup
+  "Checks that hiccup can be rendered and returns it.
+  This allows exceptions to capture the note which will be helpful for debugging."
+  [note k h]
+  (try #?(:clj (hiccup.core/html h))
+       h
+       (catch #?(:clj Exception :cljs :default) ex
+         (throw (ex-info (str "bad " k ": " h)
+                         {:id     ::bad-hiccup
+                          :k      k
+                          :hiccup h
+                          :note   note}
+                         ex)))))
+
+(defn hiccups
+  "Returns all hiccups present in the notebook"
+  [{:as notebook :keys [notes]}]
+  (for [note notes
+        k hiccup-keys
+        :let [h (get note k)]
+        :when h]
+    (check-hiccup note k h)))
+
+(defn page
+  "Returns a hiccup representation of a page"
+  [{:as notebook :keys [resource-hiccups]}]
   (let [{:keys [head body]} resource-hiccups]
     (list [:head head]
-          [:body hiccups body])))
+          [:body (hiccups notebook) body])))
 
 (defn render-notebook
   "Returns an edn string representation of a notebook as a hiccup page"
   [notebook]
   (-> (hiccups/with-hiccups notebook)
-      (resources/with-resource-hiccups)
       (page)
       (pr-str)))

--- a/src/scicloj/kindly_render/notes/to_html_page.clj
+++ b/src/scicloj/kindly_render/notes/to_html_page.clj
@@ -1,16 +1,16 @@
 (ns scicloj.kindly-render.notes.to-html-page
   (:require [hiccup.page :as page]
             [scicloj.kindly-render.entry.hiccups :as hiccups]
-            [scicloj.kindly-render.notes.resources :as resources]
             [scicloj.kindly-render.notes.to-hiccup-page :as to-hiccup-page]))
 
-(defn page [notebook]
+(defn page
+  "Given a rendered notebook, returns a HTML string page"
+  [notebook]
   (-> (to-hiccup-page/page notebook)
       (page/html5)))
 
 (defn render-notebook
-  "Given a prepared notebook, returns an HTML string page"
+  "Given a notebook, renders and returns an HTML string page"
   [notebook]
   (-> (hiccups/with-hiccups notebook)
-      (resources/with-resource-hiccups)
       (page)))

--- a/src/scicloj/kindly_render/notes/to_markdown_page.clj
+++ b/src/scicloj/kindly_render/notes/to_markdown_page.clj
@@ -2,23 +2,42 @@
   (:require [clojure.data.json :as json]
             [clojure.string :as str]
             [hiccup.core :as hiccup]
-            [scicloj.kindly-render.entry.markdowns :as markdowns]
-            [scicloj.kindly-render.notes.resources :as resources]))
+            [scicloj.kindly-render.entry.markdowns :as markdowns]))
 
-(defn page [{:as notebook :keys [resource-hiccups markdowns kindly/options]}]
-  (let [{:keys [front-matter]} options]
+(def md-keys
+  [:comment-md
+   :code-md
+   :out-md
+   :err-md
+   :md
+   :ex-md])
+
+(defn page [{:as notebook :keys [resource-hiccups notes kindly/options]}]
+  (let [{:keys [head body]} resource-hiccups
+        {:keys [front-matter]} options
+        markdowns (for [note notes
+                        k md-keys
+                        :let [md (get note k)]
+                        :when md]
+                    md)]
     (str
       (when front-matter
         (str "---" \newline
              (str/trim-newline (json/write-str front-matter)) \newline
              "---" \newline \newline))
       ;; TODO: for a book these should just go in _quarto.yml as include-in-header
-      (hiccup/html resource-hiccups) \newline
-      (str/join (str \newline \newline) markdowns) \newline)))
+
+      (when (seq head)
+        (str (str/join \newline (map #(hiccup/html %) head))
+             \newline \newline))
+      (str/join (str \newline \newline) markdowns) \newline
+      (when (seq body)
+        (str \newline
+             (str/join \newline (map #(hiccup/html %) body))
+             \newline)))))
 
 (defn render-notebook
   "Given a notebook, returns a markdown page as a string"
   [notebook]
   (-> (markdowns/with-markdowns notebook)
-      (resources/with-resource-hiccups)
       (page)))


### PR DESCRIPTION
Clay just adds :hiccup and :md to notes, which is the correct approach.
Relying on mutable dynamic var *deps* and *js* can be avoided.